### PR TITLE
Feature/edit delete activities api

### DIFF
--- a/api_backend_server/web_app/models/__init__.py
+++ b/api_backend_server/web_app/models/__init__.py
@@ -19,7 +19,7 @@ class Users(Document):
     email_confirmed = BooleanField(default=False)
 
     @staticmethod
-    def delete_user(public_id):
+    def delete_user(public_id: str) -> bool:
         (user,) = Users.objects(public_id=public_id)
         user.delete()
 
@@ -42,6 +42,23 @@ class Categories(Document):
     name = StringField(max_length=50)
     icon_name = StringField(max_length=50)
 
+    @staticmethod
+    def get_specific_category(category_id: str) -> Document:
+        try:
+            (category,) = Categories.objects(public_id=category_id)
+        except ValueError as e:
+            if (
+                len(e.args) > 0
+                and e.args[0] == "not enough values to unpack (expected 1, got 0)"
+            ):
+                raise ValueError(
+                    f"Category with id={category_id} does not exist in the Database"
+                ) from e
+            else:
+                raise e
+
+        return category
+
 
 class Activities(Document):
     activity_id = UUIDField(binary=False, required=True)
@@ -50,3 +67,36 @@ class Activities(Document):
     activity_start = DateTimeField()
     activity_end = DateTimeField()
     category = ReferenceField(Categories)
+
+    @staticmethod
+    def get_specific_activity(activity_id: str) -> Document:
+        try:
+            (activity,) = Activities.objects(activity_id=activity_id)
+        except ValueError as e:
+            if (
+                len(e.args) > 0
+                and e.args[0] == "not enough values to unpack (expected 1, got 0)"
+            ):
+                raise ValueError(
+                    f"Activity with id={activity_id} does not exist in the Database"
+                ) from e
+            else:
+                raise e
+
+        return activity
+
+    @staticmethod
+    def delete_specific_activity(activity_id: str) -> bool:
+        activity = Activities.get_specific_activity(activity_id=activity_id)
+
+        activity.delete()
+
+        return True
+
+    @staticmethod
+    def edit_specific_activity(activity_id: str, **kwargs: dict) -> Document:
+        activity = Activities.get_specific_activity(activity_id=activity_id)
+
+        updated_activity = activity.update(**kwargs)
+
+        return updated_activity

--- a/api_backend_server/web_app/openapi.yaml
+++ b/api_backend_server/web_app/openapi.yaml
@@ -238,6 +238,62 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/activity"
+    delete:
+      tags:
+        - activities
+      summary: Delete a user activity record
+      operationId: apis.activities.delete_user_activity
+      security:
+        - jwt: ['user']
+      parameters:
+        - in: query
+          name: activity_id
+          description: Activity ID that needs to be deleted
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Deletes an activity with provided activity id
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Activity 4f175f70-d192-42a4-bd74-6f5b5baf7963 successfully deleted
+    put:
+      tags:
+        - activities
+      summary: Edits a user activity record with data provided in payload
+      operationId: apis.activities.edit_user_activity
+      security:
+        - jwt: ['user']
+      parameters:
+        - in: query
+          name: activity_id
+          description: Activity ID that needs to be updated
+          schema:
+            type: string
+          required: true
+      requestBody:
+        required: True
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/activity"
+      responses:
+        '200':
+          description: Updates an activity with provided data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Activity 4f175f70-d192-42a4-bd74-6f5b5baf7963 successfully updated
   /api/categories:
     get:
       tags:

--- a/api_backend_server/web_app/openapi.yaml
+++ b/api_backend_server/web_app/openapi.yaml
@@ -214,9 +214,9 @@ paths:
               schema:
                 type: object
                 properties:
-                  message:
+                  activity_id:
                     type: string
-                    example: new activity record created
+                    example: 4f175f70-d192-42a4-bd74-6f5b5baf7963
         default:
           description: Unexpected error
     get:


### PR DESCRIPTION
Adds two new REST methods to activities API:
- DELETE (deletes an activity by its id)
- PUT (updates an activity by its id with content of the payload)